### PR TITLE
Initialize genai-scrubber extension

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,23 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 11,
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {},
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: extension
+          path: genai-scrubber.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.zip
+.vscode/

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky:debug $*"
+  }
+  husky_dir="$(cd "$(dirname "$0")/.." && pwd -P)"
+  debug "husky_dir: $husky_dir"
+  readonly husky_dir
+  export PATH="$husky_dir/bin:$PATH"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# GenAI-Scrubber
-“AI 프롬프트 개인정보 0 노출” 프로젝트
+# genai-scrubber
+
+Chrome/Edge extension that scrubs personal data from text and images locally before they are uploaded. Built with Manifest V3, TypeScript, React, and crxjs.
+
+## Development
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+## Build
+
+```bash
+pnpm run build
+```
+
+## Testing
+
+```bash
+pnpm run test
+pnpm run e2e
+```

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": 3,
+  "name": "genai-scrubber",
+  "description": "Scrubs personal data from text and images before upload.",
+  "version": "0.1.0",
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting",
+    "webRequest",
+    "alarms"
+  ],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "src/background/serviceWorker.ts"
+  },
+  "action": {
+    "default_popup": "popup/Popup.html",
+    "default_icon": {
+      "16": "public/icons/16.png",
+      "32": "public/icons/32.png"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/content.ts"],
+      "run_at": "document_start"
+    }
+  ],
+  "icons": {
+    "16": "public/icons/16.png",
+    "32": "public/icons/32.png",
+    "48": "public/icons/48.png",
+    "128": "public/icons/128.png"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "genai-scrubber",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build && cd dist && zip -r ../genai-scrubber.zip .",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,json,md}'",
+    "test": "vitest",
+    "e2e": "vitest run --config vitest.e2e.config.ts"
+  },
+  "dependencies": {
+    "@crxjs/vite-plugin": "^2.0.2",
+    "@vitejs/plugin-react": "^4.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "onnxruntime-web": "^1.16.0",
+    "tesseract.js": "^4.1.1",
+    "opencv.js": "^1.2.1",
+    "crypto-js": "^4.1.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "vite": "^4.3.0",
+    "eslint": "^8.50.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react": "^7.32.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "prettier": "^3.0.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^13.2.0",
+    "vitest": "^0.34.0",
+    "puppeteer": "^21.3.0",
+    "jsdom": "^22.0.0",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/icons/128.png
+++ b/public/icons/128.png
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/public/icons/16.png
+++ b/public/icons/16.png
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/public/icons/32.png
+++ b/public/icons/32.png
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/public/icons/48.png
+++ b/public/icons/48.png
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/public/policy/default.json
+++ b/public/policy/default.json
@@ -1,0 +1,3 @@
+[
+  {"id": "phone", "pattern": "\\d{3}-\\d{4}-\\d{4}", "severity": 1}
+]

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -1,0 +1,19 @@
+import puppeteer from 'puppeteer';
+import { expect, test } from 'vitest';
+
+test('paste sanitizes text', async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('https://chat.openai.com');
+  await page.evaluate(() => {
+    document.body.innerHTML = '<textarea id="t"></textarea>';
+  });
+  await page.focus('#t');
+  await page.evaluate(() => navigator.clipboard.writeText('010-1234-5678'));
+  await page.keyboard.down('Control');
+  await page.keyboard.press('v');
+  await page.keyboard.up('Control');
+  const value = await page.$eval('#t', (el: HTMLTextAreaElement) => el.value);
+  expect(value).not.toContain('010-1234-5678');
+  await browser.close();
+});

--- a/src/__tests__/scrubber.test.ts
+++ b/src/__tests__/scrubber.test.ts
@@ -1,0 +1,7 @@
+import { scrubText } from '../content/scrubber';
+
+test('scrub phone number', async () => {
+  const { clean, stats } = await scrubText('call me 010-1234-5678');
+  expect(clean).not.toContain('010-1234-5678');
+  expect(stats.replacedPhones).toBe(1);
+});

--- a/src/background/serviceWorker.ts
+++ b/src/background/serviceWorker.ts
@@ -1,0 +1,15 @@
+import { log } from '../utils/logger';
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  (details) => {
+    const headers = details.requestHeaders || [];
+    headers.push({ name: 'X-GenAI-Scrubber', value: '1' });
+    return { requestHeaders: headers };
+  },
+  { urls: ['<all_urls>'] },
+  ['blocking', 'requestHeaders'],
+);
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  log('Alarm fired', alarm.name);
+});

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,0 +1,28 @@
+import { scrubText, scrubImage } from './scrubber';
+
+function handlePaste(ev: ClipboardEvent): void {
+  const clipboardData = ev.clipboardData;
+  if (!clipboardData) return;
+  const text = clipboardData.getData('text');
+  if (text) {
+    ev.preventDefault();
+    scrubText(text).then(({ clean }) => {
+      clipboardData.setData('text/plain', clean);
+      document.execCommand('insertText', false, clean);
+    });
+  }
+}
+
+document.addEventListener('paste', handlePaste, true);
+
+document.addEventListener('change', (e) => {
+  const target = e.target as HTMLInputElement;
+  if (target.type === 'file' && target.files?.length) {
+    const file = target.files[0];
+    scrubImage(file).then(({ blob }) => {
+      const dt = new DataTransfer();
+      dt.items.add(new File([blob], file.name, { type: file.type }));
+      target.files = dt.files;
+    });
+  }
+});

--- a/src/content/scrubber.ts
+++ b/src/content/scrubber.ts
@@ -1,0 +1,79 @@
+import { InferenceSession } from 'onnxruntime-web';
+import { ScrubStats } from '../types';
+import { log } from '../utils/logger';
+
+let nerLoaded = false;
+// Placeholder for spaCy NER WASM
+export async function loadNER(): Promise<void> {
+  if (!nerLoaded) {
+    // TODO: load pyodide and spaCy wasm
+    nerLoaded = true;
+  }
+}
+
+const faceModel = 'src/wasm/yolov8_face.onnx';
+let faceSession: InferenceSession | null = null;
+
+async function loadFaceModel(): Promise<void> {
+  if (!faceSession) {
+    faceSession = await InferenceSession.create(faceModel);
+  }
+}
+
+interface Mapping {
+  [token: string]: string;
+}
+
+const mapping: Mapping = {};
+let counter = 0;
+
+function token(label: string): string {
+  counter += 1;
+  return `@${label}${counter}`;
+}
+
+/** Scrub text using spaCy NER */
+export async function scrubText(raw: string): Promise<{ clean: string; stats: ScrubStats }> {
+  await loadNER();
+  const stats: ScrubStats = {
+    replacedNames: 0,
+    replacedPhones: 0,
+    replacedAddresses: 0,
+    replacedStudentIds: 0,
+  };
+  let clean = raw;
+  // Simple regex-based placeholder
+  clean = clean.replace(/(\d{3}-\d{4}-\d{4})/g, (match) => {
+    const t = token('PHONE');
+    mapping[t] = match;
+    stats.replacedPhones += 1;
+    return t;
+  });
+  return { clean, stats };
+}
+
+/** Scrub image by blurring faces and text */
+export async function scrubImage(file: File | Blob): Promise<{ blob: Blob; stats: ScrubStats }> {
+  await loadFaceModel();
+  const stats: ScrubStats = {
+    replacedNames: 0,
+    replacedPhones: 0,
+    replacedAddresses: 0,
+    replacedStudentIds: 0,
+    imagesProcessed: 1,
+  };
+  // Load image into canvas
+  const img = await createImageBitmap(file);
+  const canvas = new OffscreenCanvas(img.width, img.height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0);
+  // TODO: run face detection and blur
+  // TODO: OCR and scrubText over extracted text
+  const blob = await canvas.convertToBlob();
+  log('scrubbed image');
+  return { blob, stats };
+}
+
+export function undo(tokenStr: string): string | undefined {
+  return mapping[tokenStr];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/popup/Popup.html
+++ b/src/popup/Popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>genai-scrubber</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="index.tsx"></script>
+  </body>
+</html>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useEffect, useState } from 'react';
+
+export function Popup(): JSX.Element {
+  const [count, setCount] = useState(0);
+  const [logs, setLogs] = useState<string[]>([]);
+
+  useEffect(() => {
+    chrome.storage.sync.get(['count', 'logs'], (data) => {
+      setCount(data.count || 0);
+      setLogs(data.logs || []);
+    });
+  }, []);
+
+  return (
+    <div className="p-4 w-60">
+      <h1 className="text-lg font-bold mb-2">genai-scrubber</h1>
+      <p>Today: {count} scrubs</p>
+      <ul className="text-xs mt-2 list-disc ml-4">
+        {logs.slice(0, 10).map((l, i) => (
+          <li key={i}>{l}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+export default Popup;

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,0 +1,11 @@
+import "../index.css";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Popup from './Popup';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('root');
+  if (container) {
+    createRoot(container).render(<Popup />);
+  }
+});

--- a/src/popup/options.html
+++ b/src/popup/options.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Options</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="optionsIndex.tsx"></script>
+  </body>
+</html>

--- a/src/popup/options.tsx
+++ b/src/popup/options.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useEffect, useState } from 'react';
+
+export default function Options(): JSX.Element {
+  const [learning, setLearning] = useState(false);
+
+  useEffect(() => {
+    chrome.storage.sync.get('learning', (data) => setLearning(Boolean(data.learning)));
+  }, []);
+
+  const toggle = () => {
+    const next = !learning;
+    setLearning(next);
+    chrome.storage.sync.set({ learning: next });
+  };
+
+  return (
+    <div className="p-4">
+      <label className="flex items-center space-x-2">
+        <input type="checkbox" checked={learning} onChange={toggle} />
+          <span>Learning mode (don&apos;t replace, just warn)</span>
+      </label>
+    </div>
+  );
+}

--- a/src/popup/optionsIndex.tsx
+++ b/src/popup/optionsIndex.tsx
@@ -1,0 +1,11 @@
+import "../index.css";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Options from './options';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('root');
+  if (container) {
+    createRoot(container).render(<Options />);
+  }
+});

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,7 @@
+export interface ScrubStats {
+  replacedNames: number;
+  replacedPhones: number;
+  replacedAddresses: number;
+  replacedStudentIds: number;
+  imagesProcessed?: number;
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,48 @@
+import { encrypt, decrypt } from './crypto';
+
+const DB_NAME = 'genai-cache';
+const STORE = 'items';
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore(STORE, { keyPath: 'id' });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+  return dbPromise;
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+export async function save(id: string, data: string, key: string): Promise<void> {
+  const db = await openDb();
+  const tx = db.transaction(STORE, 'readwrite');
+  tx.objectStore(STORE).put({ id, data: await encrypt(data, key), ts: Date.now() });
+  await txDone(tx);
+}
+
+export async function load(id: string, key: string): Promise<string | undefined> {
+  const db = await openDb();
+  const tx = db.transaction(STORE, 'readonly');
+  const req = tx.objectStore(STORE).get(id);
+  const record = await new Promise<{ id: string; data: string; ts: number } | undefined>((resolve) => {
+    req.onsuccess = () => resolve(req.result as { id: string; data: string; ts: number });
+    req.onerror = () => resolve(undefined);
+  });
+  if (record && Date.now() - record.ts < 86400000) {
+    return decrypt(record.data, key);
+  }
+  return undefined;
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,10 @@
+import CryptoJS from 'crypto-js';
+
+export async function encrypt(text: string, key: string): Promise<string> {
+  return CryptoJS.AES.encrypt(text, key).toString();
+}
+
+export async function decrypt(cipher: string, key: string): Promise<string> {
+  const bytes = CryptoJS.AES.decrypt(cipher, key);
+  return bytes.toString(CryptoJS.enc.Utf8);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,6 @@
+export function log(...args: unknown[]): void {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.log('[genai-scrubber]', ...args);
+  }
+}

--- a/src/wasm/ko_ner.wasm
+++ b/src/wasm/ko_ner.wasm
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/src/wasm/yolov8_face.onnx
+++ b/src/wasm/yolov8_face.onnx
@@ -1,0 +1,1 @@
+// <<<binary placeholder>>>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['src/**/*.{ts,tsx,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "lib": ["dom", "es2020"],
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { crx } from '@crxjs/vite-plugin';
+import manifest from './manifest.json';
+
+export default defineConfig({
+  plugins: [react(), crx({ manifest })],
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- set up Chrome extension project with TypeScript/React and crxjs/vite
- add placeholder WASM models and icons
- implement text/image scrubbing stubs and content script
- create popup and options UIs
- add IndexedDB cache utilities
- configure linting, formatting, testing, and GitHub Actions CI

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint`
- `pnpm test` *(fails: Could not find Chrome for Puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_6874b1245218832d8ae0a08468ccce2d